### PR TITLE
Fix nDims dispatch for external emitter types, bump v0.2.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SMLMDriftCorrection"
 uuid = "34bda2d1-2fff-475a-a8c4-7f53d4251312"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["klidke@unm.edu"]
 
 [deps]

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -26,11 +26,12 @@ function filter_emitters(smld::SMLD, keep::Integer)
 end
 
 """
-Determines from the type of the input smld if the data is 2D or 3D.
+Determines if the data is 2D or 3D by dispatching on the emitter type parameter.
+Falls back to `hasfield` check for external emitter types (e.g. GaussMLE.Emitter2DFitSigma).
 """
-function nDims(smld::SMLD)
-    return occursin("2D", string(typeof(smld))) ? 2 : 3
-end
+nDims(::BasicSMLD{T, E}) where {T, E<:Union{Emitter2D,Emitter2DFit}} = 2
+nDims(::BasicSMLD{T, E}) where {T, E<:Union{Emitter3D,Emitter3DFit}} = 3
+nDims(smld::SMLD) = hasfield(typeof(first(smld.emitters)), :z) ? 3 : 2
 
 """
     compute_chunk_params(n_frames; chunk_frames=0, n_chunks=0)


### PR DESCRIPTION
## Summary

- Fix `nDims` to dispatch on emitter type parameter instead of string-matching SMLD type name
- Adds type dispatch for known SMLMData types (`Emitter2D/3D`, `Emitter2DFit/3DFit`)
- Falls back to `hasfield(:z)` for external emitter types (e.g. `GaussMLE.Emitter2DFitSigma`)
- Fixes crash when running drift correction on `BasicSMLD` holding 2D-only emitters without `.z` field
- Bump version to 0.2.0

## Bug

`correctdrift!` accessed `.z` on emitters that don't have it (e.g. `Emitter2DFitSigma`), because `nDims` checked the SMLD type name for "2D" — `BasicSMLD` doesn't contain "2D", so it returned 3.

## Test plan
- [x] All 64 tests pass locally
- [ ] CI passes

Generated with [Claude Code](https://claude.com/claude-code)