### PR TITLE
Fix continuous-mode residual drift: determinism fixes + coarse-to-fine 2-pass recipe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,15 @@ For trajectory plotting in continuous mode:
 traj = drift_trajectory(info.model; cumulative=true)
 ```
 
+**Residual drift from chunk stitching (coarse-to-fine 2-pass)**: With `n_chunks > 1`, chunks are fit independently and stitched by endpoint chaining (inter-shift pinned to the chained value, see Continuous Mode Internals). Per-chunk fit bias therefore *accumulates across seams*, leaving a small coherent **directional** residual drift (observed ~17nm on a 20k-frame / 10-chunk DNA-PAINT nanoruler) that smears fine structure. Chunking can't simply be removed — a single global polynomial (`n_chunks=1`) cannot bootstrap from the uncorrected, drift-smeared cloud (flat entropy gradient → optimizer stalls). The robust, config-only fix is a two-pass coarse-to-fine: chunk to bootstrap, then refine the de-smeared output with a single low-degree global polynomial (no seams):
+```julia
+# Pass 1: chunked bootstrap
+(smld_coarse, info1) = driftcorrect(smld; dataset_mode=:continuous, n_chunks=10, degree=3, quality=:iterative)
+# Pass 2: single-poly refine on pass-1 output (removes the stitch-accumulation residual)
+(smld_corrected, info2) = driftcorrect(smld_coarse; dataset_mode=:continuous, n_chunks=1, degree=2, quality=:iterative)
+```
+A low `degree` (2-3) suffices for pass 2 (the residual is smooth/low-frequency); Nelder-Mead converges it fine. Do NOT use `warm_start=info1.model` for pass 2 — a chunked model's per-chunk polynomials are normalized to each chunk's frame domain and can't be reinterpreted on the full domain; use the two sequential calls. Measure residual with consecutive/endpoint time-block cross-correlation (`findshift`), not block-vs-global (which under-reads on smeared data); and run a random-split control before attributing any residual spread to field-dependence (small-group CC spread is noise-inflated).
+
 ## Usage Patterns
 
 ### Basic Usage

--- a/src/align.jl
+++ b/src/align.jl
@@ -21,7 +21,13 @@ Each SMLD is assumed to be an independent acquisition of the same FOV/structure.
 Tuple `(aligned_smlds, info::AlignInfo)` where:
 - `aligned_smlds`: Vector of aligned SMLDs (first is unchanged)
 - `info.shifts[i]`: translation component for `smlds[i]` (`shifts[1]` = zeros)
-- `info.transforms[i]`: full transform (ShiftTransform or AffineTransform2D/3D)
+- `info.transforms[i]`: diagnostic transform (ShiftTransform for `:shift`; a similarity
+  fit `AffineTransform2D`/`AffineTransform3D` for `:affine`).
+- `info.diagnostic`: `nothing` for `:shift`; for `:affine` a NamedTuple with
+  `affine_coeffs[i] = (a, b, c, d, e, f)` and `global_shifts[i]` — the **exact**
+  per-dataset correction applied (summed across internal passes). The similarity
+  stored in `info.transforms[i]` is only a best-fit approximation of this general
+  affine.
 
 # Example
 ```julia
@@ -31,7 +37,8 @@ info.shifts  # [zeros(2), [dx2, dy2], [dx3, dy3], ...]
 
 # Affine (rotation + scale + translation)
 (aligned, info) = align_smld(smlds; transform=:affine)
-info.transforms[2]  # AffineTransform2D(θ, scale, tx, ty)
+info.transforms[2]        # AffineTransform2D(θ, scale, tx, ty) — similarity approximation
+info.diagnostic.affine_coeffs[2]  # (a, b, c, d, e, f) — actual correction applied
 ```
 """
 function align_smld(smlds::Vector{<:SMLD}; kwargs...)
@@ -97,7 +104,7 @@ function _align_shift(smlds, N, ndims_ref, config, t0)
     end
 
     transforms = AbstractAlignTransform[ShiftTransform(s) for s in shifts]
-    info = AlignInfo(shifts, transforms, elapsed, config.method, config.transform, :cpu)
+    info = AlignInfo(shifts, transforms, elapsed, config.method, config.transform, :cpu, nothing)
     return (aligned, info)
 end
 
@@ -114,6 +121,13 @@ function _align_affine_fft(smlds, N, ndims_ref, config, t0)
     transforms[1] = AffineTransform2D(0.0, 1.0, 0.0, 0.0)
     aligned = Vector{typeof(smlds[1])}(undef, N)
     aligned[1] = smlds[1]
+
+    # Record the exact affine correction actually applied per dataset, so callers
+    # can recover the full general affine (transforms[i] stores only a similarity fit).
+    affine_coeffs = Vector{NTuple{6, Float64}}(undef, N)
+    global_shifts = Vector{Vector{Float64}}(undef, N)
+    affine_coeffs[1] = (0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    global_shifts[1] = zeros(ndims_ref)
 
     for i in 2:N
         # Pass 1: global shift + affine from shift field
@@ -151,14 +165,20 @@ function _align_affine_fft(smlds, N, ndims_ref, config, t0)
             println("  smlds[$i] pass2: rms=$(round(result2.rms_residual*1000; digits=1))nm")
         end
 
-        # Total shift at centroid
+        # Record the exact correction applied (sum of two passes)
+        total_a = a + a2; total_b = b + b2; total_c = c + c2
+        total_d = d + d2; total_e = e + e2; total_f = f + f2
+        total_global = result.global_shift .+ result2.global_shift
+        affine_coeffs[i] = (total_a, total_b, total_c, total_d, total_e, total_f)
+        global_shifts[i] = collect(total_global)
+
+        # Total shift at centroid (diagnostic similarity fit — independent x/y scale
+        # and shear from the general affine are not captured here).
         cx = mean(em.x for em in smlds[i].emitters)
         cy = mean(em.y for em in smlds[i].emitters)
-        gs = result.global_shift .+ result2.global_shift
-        total_a = a + a2; total_e = e + e2
-        shifts[i] = [gs[1] + a*cx + b*cy + c, gs[2] + d*cx + e*cy + f]
+        shifts[i] = [total_global[1] + a*cx + b*cy + c, total_global[2] + d*cx + e*cy + f]
 
-        θ_fit = atan(((d + d2) - (b + b2)) / 2)
+        θ_fit = atan((total_d - total_b) / 2)
         s_fit = sqrt(abs((1 + total_a) * (1 + total_e)))
         transforms[i] = AffineTransform2D(θ_fit, s_fit, shifts[i][1], shifts[i][2])
     end
@@ -166,7 +186,8 @@ function _align_affine_fft(smlds, N, ndims_ref, config, t0)
     elapsed = time() - t0
     config.verbose >= 1 && println("align_smld: aligned $N SMLDs (fft, affine) in $(round(elapsed; digits=2))s")
 
-    info = AlignInfo(shifts, transforms, elapsed, config.method, config.transform, :cpu)
+    diag = (affine_coeffs = affine_coeffs, global_shifts = global_shifts)
+    info = AlignInfo(shifts, transforms, elapsed, config.method, config.transform, :cpu, diag)
     return (aligned, info)
 end
 
@@ -258,7 +279,26 @@ function _align_entropy!(shifts, smlds, ndims_ref, config)
         myfun = θ -> entropy_cost(θ) + λ * sum((θ .- θ_cc).^2)
 
         opt = Optim.Options(iterations=10000, g_abstol=1e-8, show_trace=false)
-        res = optimize(myfun, θ_cc, BFGS(), opt)
+        # Deterministic objective for BFGS: freeze state during optimize, drive
+        # KDTree rebuilds from an outer loop (mirrors findinter!).
+        state.allow_rebuild = true
+        entropy_cost(θ_cc)
+        state.allow_rebuild = false
+
+        θ0 = copy(θ_cc)
+        local res
+        for _ in 1:3
+            res = optimize(myfun, θ0, BFGS(), opt)
+            θ0 = Float64.(res.minimizer)
+            Δ2 = 0.0
+            for dim in 1:ndims_ref
+                Δ2 += (θ0[dim] - state.last_shift[dim])^2
+            end
+            sqrt(Δ2) < state.rebuild_threshold && break
+            state.allow_rebuild = true
+            entropy_cost(θ0)
+            state.allow_rebuild = false
+        end
         shifts[i] = Float64.(res.minimizer)
     end
 end

--- a/src/cost_entropy.jl
+++ b/src/cost_entropy.jl
@@ -30,9 +30,17 @@ end
 H_i(D) is the entropy of the distribution p(r), where
 D = {d(1),...,d(L)} is the drift at all frames (1 to L).
 The quantity below is Gaussian Mixture Model single components
-summed over all localizations provided.
+**summed** over all localizations provided (total Shannon entropy, not per-point).
 
 σ_x and σ_y are localization uncertainties.
+
+!!! warning "Scale note"
+    `entropy_HD` returns a sum of size ~N, while the neighbor divergence term
+    used in `entropy1_*`/`ub_entropy` is averaged per-localization (`out / N`).
+    The formula `entropy_HD - out/N` is therefore **dominated by the H(D) term**
+    as N grows — by design, since `entropy_HD` is θ-independent and is only a
+    constant offset for the optimizer. If you want a dataset-size-independent
+    number for diagnostics, divide by `length(σ_x)`.
 """
 function entropy_HD(σ_x::Vector{T}, σ_y::Vector{T}) where {T<:Real}
     c = T(0.5) * log(T(2) * T(π) * T(ℯ))
@@ -308,6 +316,10 @@ end
 
 """
 Entropy upper bound based on maxn nearest neighbors of each localization (2D).
+
+Returns `entropy_HD(σ_x, σ_y) - out/N`, where the first term is a **sum** over
+N localizations and the second is a per-localization average. The result scales
+with N through the `entropy_HD` term; divide by `length(x)` for per-locus bits.
 
 # Arguments
 - x, y: Vectors of localization positions

--- a/src/costfuns.jl
+++ b/src/costfuns.jl
@@ -25,12 +25,16 @@ mutable struct NeighborState{T<:Real}
     rebuild_count::Int                      # number of rebuilds (for diagnostics)
     k::Int                                  # number of neighbors
     kldiv::Vector{T}                        # pre-allocated divergence buffer (length k)
+    allow_rebuild::Bool                     # when false, cost fun sees a frozen objective
 end
 
 function NeighborState(N::Int, k::Int, rebuild_threshold::T) where {T<:Real}
     neighbor_indices = Matrix{Int}(undef, k, N)
     kldiv = Vector{T}(undef, k)
-    return NeighborState{T}(neighbor_indices, T(0), rebuild_threshold, 0, k, kldiv)
+    # Default allow_rebuild=true preserves legacy behavior for any external callers;
+    # findintra!/findinter! set this to false so each optimize() call sees a
+    # deterministic objective, and rebuilds are driven from an outer loop.
+    return NeighborState{T}(neighbor_indices, T(0), rebuild_threshold, 0, k, kldiv, true)
 end
 
 """
@@ -123,6 +127,7 @@ Check if neighbors need rebuilding based on drift magnitude change.
 function maybe_rebuild_neighbors!(state::NeighborState{T},
                                    x_work::Vector{T}, y_work::Vector{T},
                                    intra::AbstractIntraDrift, nframes::Int) where {T<:Real}
+    state.allow_rebuild || return
     current_drift = max_drift_magnitude(intra, nframes)
 
     if abs(current_drift - state.last_rebuild_drift) > state.rebuild_threshold
@@ -139,6 +144,7 @@ end
 function maybe_rebuild_neighbors!(state::NeighborState{T},
                                    x_work::Vector{T}, y_work::Vector{T}, z_work::Vector{T},
                                    intra::AbstractIntraDrift, nframes::Int) where {T<:Real}
+    state.allow_rebuild || return
     current_drift = max_drift_magnitude(intra, nframes)
 
     if abs(current_drift - state.last_rebuild_drift) > state.rebuild_threshold
@@ -288,18 +294,19 @@ mutable struct InterNeighborState{T<:Real}
     k::Int                                  # number of neighbors
     kldiv::Vector{T}                        # pre-allocated divergence buffer
     needs_initial_build::Bool               # true until first build
+    allow_rebuild::Bool                     # when false, cost fun sees a frozen objective
 end
 
 function InterNeighborState(N_n::Int, k::Int, rebuild_threshold::T) where {T<:Real}
     neighbor_indices = Matrix{Int}(undef, k, N_n)
     kldiv = Vector{T}(undef, k)
-    return InterNeighborState{T}(neighbor_indices, T[Inf, Inf], rebuild_threshold, 0, k, kldiv, true)
+    return InterNeighborState{T}(neighbor_indices, T[Inf, Inf], rebuild_threshold, 0, k, kldiv, true, true)
 end
 
 function InterNeighborState3D(N_n::Int, k::Int, rebuild_threshold::T) where {T<:Real}
     neighbor_indices = Matrix{Int}(undef, k, N_n)
     kldiv = Vector{T}(undef, k)
-    return InterNeighborState{T}(neighbor_indices, T[Inf, Inf, Inf], rebuild_threshold, 0, k, kldiv, true)
+    return InterNeighborState{T}(neighbor_indices, T[Inf, Inf, Inf], rebuild_threshold, 0, k, kldiv, true, true)
 end
 
 """
@@ -363,10 +370,14 @@ function costfun_entropy_inter_2D_merged(θ,
 
     k = min(maxn, N_combined - 1)
 
-    # Check if we need to rebuild neighbors
+    # Check if we need to rebuild neighbors.
+    # Initial build is always allowed; subsequent rebuilds only when state.allow_rebuild.
+    # findinter! freezes the state during optimize() and drives rebuilds from an outer loop
+    # to keep BFGS's view of the objective deterministic.
     need_rebuild = state === nothing ||
                    state.needs_initial_build ||
-                   sqrt((θ[1] - state.last_shift[1])^2 + (θ[2] - state.last_shift[2])^2) > state.rebuild_threshold
+                   (state.allow_rebuild &&
+                    sqrt((θ[1] - state.last_shift[1])^2 + (θ[2] - state.last_shift[2])^2) > state.rebuild_threshold)
 
     local idxs  # for stateless fallback
     if need_rebuild
@@ -461,10 +472,14 @@ function costfun_entropy_inter_3D_merged(θ,
 
     k = min(maxn, N_combined - 1)
 
-    # Check if we need to rebuild neighbors
+    # Check if we need to rebuild neighbors.
+    # Initial build is always allowed; subsequent rebuilds only when state.allow_rebuild.
+    # findinter! freezes the state during optimize() and drives rebuilds from an outer loop
+    # to keep BFGS's view of the objective deterministic.
     need_rebuild = state === nothing ||
                    state.needs_initial_build ||
-                   sqrt((θ[1] - state.last_shift[1])^2 + (θ[2] - state.last_shift[2])^2 + (θ[3] - state.last_shift[3])^2) > state.rebuild_threshold
+                   (state.allow_rebuild &&
+                    sqrt((θ[1] - state.last_shift[1])^2 + (θ[2] - state.last_shift[2])^2 + (θ[3] - state.last_shift[3])^2) > state.rebuild_threshold)
 
     local idxs
     if need_rebuild

--- a/src/crosscorr.jl
+++ b/src/crosscorr.jl
@@ -533,21 +533,28 @@ function findshift_damped(smld1::T, smld2::T;
     # Convert prior_shift to pixel coordinates
     prior_px = prior_shift ./ histbinsize
 
-    # Apply Gaussian damping centered at prior_shift
+    # Apply Gaussian damping centered at the CC peak implied by prior_shift.
+    # Shift convention here is `shift = center - peak`, so for a given prior_shift
+    # the implied peak sits at pixel index (mid - prior_px). The Gaussian weight at
+    # pixel (i, j) must measure distance to that peak:
+    #     d = (i - mid) - (-prior_px) = (i - mid) + prior_px
+    # Guard against prior_sigma <= 0 or histbinsize extremes that would give σ_px = 0
+    # (Gaussian would collapse to a delta and zero the entire CC).
     σ_px = prior_sigma / histbinsize
+    σ_px = max(σ_px, one(σ_px))  # at least 1 pixel worth of tolerance
     if n_dims == 2
         for j in 1:size(cc, 2), i in 1:size(cc, 1)
-            di = (i - mid1) - prior_px[1]
-            dj = (j - mid2) - prior_px[2]
+            di = (i - mid1) + prior_px[1]
+            dj = (j - mid2) + prior_px[2]
             weight = exp(-(di^2 + dj^2) / (2 * σ_px^2))
             cc[i, j] *= weight
         end
     else  # 3D
         mid3 = size(cc, 3) ÷ 2 + 1
         for k in 1:size(cc, 3), j in 1:size(cc, 2), i in 1:size(cc, 1)
-            di = (i - mid1) - prior_px[1]
-            dj = (j - mid2) - prior_px[2]
-            dk = (k - mid3) - (length(prior_shift) > 2 ? prior_px[3] : 0.0)
+            di = (i - mid1) + prior_px[1]
+            dj = (j - mid2) + prior_px[2]
+            dk = (k - mid3) + (length(prior_shift) > 2 ? prior_px[3] : 0.0)
             weight = exp(-(di^2 + dj^2 + dk^2) / (2 * σ_px^2))
             cc[i, j, k] *= weight
         end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -63,6 +63,38 @@ config = DriftConfig(; quality=:iterative, degree=3, verbose=1)
 # Extract drift trajectory for plotting
 traj = drift_trajectory(info.model)
 ```
+
+# Reducing residual drift in continuous mode (coarse-to-fine 2-pass)
+
+In `:continuous` mode with `n_chunks > 1`, each chunk is fit independently and the
+chunks are stitched by polynomial endpoint chaining (the inter-shift is pinned to
+the chained value). Per-chunk fit bias therefore *accumulates across chunk seams*,
+leaving a small but coherent (directional) residual drift — enough to smear
+fine structure such as 3-spot nanorulers.
+
+Chunking is nonetheless required: a single global polynomial (`n_chunks=1`) cannot
+bootstrap from an uncorrected, heavily drift-smeared point cloud (the entropy
+gradient at the origin is nearly flat, so the optimizer stalls). The robust fix is a
+two-pass coarse-to-fine sequence — chunk to bootstrap, then refine the now-sharp
+cloud with a single global polynomial (no chunk seams):
+
+```julia
+# Pass 1: chunked bootstrap (handles the bulk drift)
+(smld_coarse, info1) = driftcorrect(smld; dataset_mode=:continuous,
+                                    n_chunks=10, degree=3, quality=:iterative)
+
+# Pass 2: single-polynomial refine on the de-smeared output (removes the
+# residual the chunk stitching left behind). n_chunks=1 converges here because
+# the input cloud is already sharp. A LOW degree suffices — the residual is
+# smooth/low-frequency.
+(smld_corrected, info2) = driftcorrect(smld_coarse; dataset_mode=:continuous,
+                                       n_chunks=1, degree=2, quality=:iterative)
+```
+
+Note: do NOT try to pass `warm_start=info1.model` into an `n_chunks=1` refine — a
+chunked model's per-chunk polynomials are normalized to each chunk's own frame
+domain and cannot be reinterpreted on the full-acquisition domain. Use the two
+sequential `driftcorrect` calls above instead.
 """
 function driftcorrect(smld::SMLD;
     quality::Symbol = :singlepass,

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -151,14 +151,17 @@ function driftcorrect(smld::SMLD, config::DriftConfig)
         driftmodel = LegendrePolynomial(smld_work; degree=degree)
     end
 
+    # Preserve warm-started intra coefficients by skipping random init in findintra!
+    skip_init = warm_start !== nothing
+
     # Dispatch to appropriate quality tier (using ROI-subsampled data for estimation)
     if quality == :fft
         result = _driftcorrect_fft!(driftmodel, smld_estimation, dataset_mode, verbose)
     elseif quality == :singlepass
-        result = _driftcorrect_singlepass!(driftmodel, smld_estimation, dataset_mode, maxn, verbose, shift_scale)
+        result = _driftcorrect_singlepass!(driftmodel, smld_estimation, dataset_mode, maxn, verbose, shift_scale; skip_init=skip_init)
     else  # :iterative
         result = _driftcorrect_iterative!(driftmodel, smld_estimation, dataset_mode, maxn,
-                                          max_iterations, convergence_tol, verbose, shift_scale)
+                                          max_iterations, convergence_tol, verbose, shift_scale; skip_init=skip_init)
     end
 
     # Apply corrections to get final SMLD
@@ -395,7 +398,8 @@ Matches original algorithm: intra first, then inter vs DS1, then inter vs earlie
 """
 function _driftcorrect_singlepass!(model::LegendrePolynomial, smld::SMLD,
                                     dataset_mode::Symbol, maxn::Int, verbose::Int,
-                                    shift_scale::Float64=1.0)
+                                    shift_scale::Float64=1.0;
+                                    skip_init::Bool=false)
     if verbose > 0
         @info("SMLMDriftCorrection: singlepass mode")
     end
@@ -403,10 +407,11 @@ function _driftcorrect_singlepass!(model::LegendrePolynomial, smld::SMLD,
     # Step 1: Intra-dataset correction (same path for both modes)
     if model.intra[1].dm[1].degree > 0
         if verbose > 0
-            @info("SMLMDriftCorrection: starting intra-dataset correction")
+            @info("SMLMDriftCorrection: starting intra-dataset correction" *
+                  (skip_init ? " (warm-started, skipping random init)" : ""))
         end
         Threads.@threads for nn = 1:smld.n_datasets
-            findintra!(model.intra[nn], smld, nn, maxn)
+            findintra!(model.intra[nn], smld, nn, maxn; skip_init=skip_init)
         end
     else
         if verbose > 0
@@ -475,13 +480,14 @@ Iterative quality tier - full intra↔inter convergence loop.
 function _driftcorrect_iterative!(model::LegendrePolynomial, smld::SMLD,
                                    dataset_mode::Symbol, maxn::Int,
                                    max_iterations::Int, convergence_tol::Float64,
-                                   verbose::Int, shift_scale::Float64=1.0)
+                                   verbose::Int, shift_scale::Float64=1.0;
+                                   skip_init::Bool=false)
     if verbose > 0
         @info("SMLMDriftCorrection: iterative mode (max_iterations=$max_iterations, tol=$convergence_tol)")
     end
 
-    # First run singlepass to initialize
-    _driftcorrect_singlepass!(model, smld, dataset_mode, maxn, verbose, shift_scale)
+    # First run singlepass to initialize (preserves warm start when skip_init=true)
+    _driftcorrect_singlepass!(model, smld, dataset_mode, maxn, verbose, shift_scale; skip_init=skip_init)
 
     # Compute initial entropy
     smld_corrected = correctdrift(smld, model)
@@ -536,9 +542,11 @@ function _driftcorrect_iterate!(model::LegendrePolynomial, smld::SMLD,
         inter_old = [copy(model.inter[n].dm) for n in 1:n_datasets]
 
         # Re-run intra with inter applied (shifted coordinates)
+        # skip_init=true: model already has coefficients from previous iteration/singlepass;
+        # re-randomizing would discard the progress we're trying to refine.
         smld_shifted = apply_inter_only(smld, model)
         Threads.@threads for nn = 1:n_datasets
-            findintra!(model.intra[nn], smld_shifted, nn, maxn)
+            findintra!(model.intra[nn], smld_shifted, nn, maxn; skip_init=true)
         end
 
         # Update inter-shifts

--- a/src/intrainter.jl
+++ b/src/intrainter.jl
@@ -98,7 +98,9 @@ Find and correct intra-dataset drift using entropy minimization with
 adaptive KDTree neighbor rebuilding.
 
 Uses KL divergence entropy cost function with adaptive neighbor tracking.
-Only rebuilds neighbors when drift changes by more than 0.5 μm.
+Each `optimize(...)` call sees a frozen KDTree, so the objective is deterministic
+for Nelder-Mead. Rebuilds happen in an outer loop, triggered only when the drift
+polynomial has moved by more than `rebuild_threshold` (μm) since the last rebuild.
 
 # Keyword Arguments
 - `skip_init=false`: If true, skip random initialization (use when warmstarted externally)
@@ -112,6 +114,11 @@ function findintra!(intra::AbstractIntraDrift,
     idx = [e.dataset for e in smld.emitters] .== dataset
     emitters = smld.emitters[idx]
     N = length(emitters)
+
+    # Guard against degenerate per-dataset subsets (empty, or too few points for KNN)
+    if N < 2
+        return
+    end
 
     # Extract vectors directly
     x = Float64[e.x for e in emitters]
@@ -137,6 +144,7 @@ function findintra!(intra::AbstractIntraDrift,
     # Pre-allocate work arrays
     x_work = similar(x)
     y_work = similar(y)
+    z_work = intra.ndims == 3 ? similar(z) : Float64[]
 
     # Adaptive entropy cost function
     k = min(maxn, N - 1)
@@ -145,20 +153,51 @@ function findintra!(intra::AbstractIntraDrift,
 
     if intra.ndims == 2
         build_neighbors!(state, x, y)
+        state.last_rebuild_drift = 0.0  # initial build was from uncorrected coords (drift=0)
         myfun = θ -> costfun_entropy_intra_2D_adaptive(θ, x, y, σ_x, σ_y, framenum, maxn, intra,
                                                        state, nframes;
                                                        x_work=x_work, y_work=y_work)
     else # 3D
-        z_work = similar(z)
         build_neighbors!(state, x, y, z)
+        state.last_rebuild_drift = 0.0
         myfun = θ -> costfun_entropy_intra_3D_adaptive(θ, x, y, z, σ_x, σ_y, σ_z, framenum, maxn, intra,
                                                        state, nframes;
                                                        x_work=x_work, y_work=y_work, z_work=z_work)
     end
 
-    # Optimize with Nelder-Mead (robust to noisy entropy landscape)
+    # Freeze state during each optimize(): BFGS/Nelder-Mead see a deterministic objective.
+    # The outer loop checks whether the drift has moved far enough to warrant rebuilding
+    # the KDTree from corrected coords, and re-runs optimize if so. A small cap prevents
+    # rare oscillation; in practice convergence is reached in 1-2 outer iterations.
+    state.allow_rebuild = false
     opt = Optim.Options(iterations=10000, f_abstol=1e-2, x_abstol=1e-4, show_trace=false)
-    res = optimize(myfun, θ0, opt)
+    max_outer = 3
+    local res
+    for _ in 1:max_outer
+        res = optimize(myfun, θ0, opt)
+        theta2intra!(intra, res.minimizer)
+        θ0 = res.minimizer
+
+        new_drift = max_drift_magnitude(intra, nframes)
+        if abs(new_drift - state.last_rebuild_drift) < state.rebuild_threshold
+            break
+        end
+
+        # Rebuild neighbors from corrected coords at current drift
+        @inbounds for i in 1:N
+            x_work[i] = correctdrift(x[i], framenum[i], intra.dm[1])
+            y_work[i] = correctdrift(y[i], framenum[i], intra.dm[2])
+        end
+        if intra.ndims == 2
+            build_neighbors!(state, x_work, y_work)
+        else
+            @inbounds for i in 1:N
+                z_work[i] = correctdrift(z[i], framenum[i], intra.dm[3])
+            end
+            build_neighbors!(state, x_work, y_work, z_work)
+        end
+        state.last_rebuild_drift = new_drift
+    end
     theta2intra!(intra, res.minimizer)
 end
 
@@ -232,6 +271,13 @@ function findinter!(dm::AbstractIntraInter,
     # Extract CORRECTED coords from reference datasets
     idx_ref = [e.dataset in ref_datasets for e in smld_corrected.emitters]
     emitters_ref = smld_corrected.emitters[idx_ref]
+
+    # Guard against empty dataset_n or empty reference set (e.g., filtered-out
+    # dataset, or a ref_datasets list with no surviving emitters). Without this
+    # guard the KDTree build would throw on 0 points.
+    if length(emitters_n) == 0 || length(emitters_ref) == 0
+        return 0.0
+    end
 
     x_ref = Float64[e.x for e in emitters_ref]
     y_ref = Float64[e.y for e in emitters_ref]
@@ -319,10 +365,40 @@ function findinter!(dm::AbstractIntraInter,
         myfun = entropy_cost
     end
 
-    # Optimize with gradient-based method for better convergence
-    # BFGS handles flat entropy landscapes better than Nelder-Mead (2x slower but ~4x more accurate)
+    # Optimize with gradient-based method for better convergence.
+    # BFGS handles flat entropy landscapes better than Nelder-Mead (2x slower but ~4x more accurate).
+    #
+    # Determinism: each optimize() call sees a frozen KDTree. The outer loop rebuilds
+    # neighbors only between optimize() calls, after the shift has moved beyond
+    # rebuild_threshold. This keeps BFGS's gradient approximation consistent — the
+    # function is not mutating underneath the optimizer.
     opt = Optim.Options(iterations=10000, g_abstol=1e-8, show_trace=false)
-    res = optimize(myfun, θ0, BFGS())
+    # Trigger the initial KDTree build at θ0 while allow_rebuild=true, then freeze.
+    state.allow_rebuild = true
+    entropy_cost(θ0)
+    state.allow_rebuild = false
+
+    max_outer = 3
+    local res
+    for _ in 1:max_outer
+        res = optimize(myfun, θ0, BFGS())
+        theta2inter!(inter, res.minimizer)
+        θ0 = res.minimizer
+
+        # Check shift change from last rebuild
+        Δ2 = 0.0
+        for dim in 1:n_dims
+            Δ2 += (θ0[dim] - state.last_shift[dim])^2
+        end
+        if sqrt(Δ2) < state.rebuild_threshold
+            break
+        end
+
+        # Force one rebuild at current θ0, then freeze for the next optimize pass
+        state.allow_rebuild = true
+        entropy_cost(θ0)
+        state.allow_rebuild = false
+    end
     theta2inter!(inter, res.minimizer)
     return res.minimum
 end

--- a/src/legendre.jl
+++ b/src/legendre.jl
@@ -32,11 +32,17 @@ end
 Normalize frame number to [-1, 1] for Legendre polynomial evaluation.
 Frame 1 maps to -1, frame n_frames maps to +1.
 
-Note: If frame is outside [1, n_frames], the Legendre polynomial evaluation will
-throw a DomainError. This is intentional - it exposes bugs in frame assignment
-rather than hiding them with defensive clamping.
+Degenerate n_frames=1 (a single-frame acquisition) maps to t=0 (interval midpoint)
+since [-1, +1] collapses — without this guard the division by `n_frames - 1` would
+throw. Polynomials degree>0 evaluate to 0 at t=0 for odd basis functions, and to
+a constant for even ones, which is the sensible behaviour when no time axis exists.
+
+Note: If frame is outside [1, n_frames] (and n_frames > 1), the Legendre polynomial
+evaluation will throw a DomainError. This is intentional - it exposes bugs in frame
+assignment rather than hiding them with defensive clamping.
 """
 function normalize_frame(frame::Int, n_frames::Int)
+    n_frames <= 1 && return 0.0
     return 2 * (frame - 1) / (n_frames - 1) - 1
 end
 

--- a/src/typedefs.jl
+++ b/src/typedefs.jl
@@ -23,6 +23,15 @@ end
 2D similarity transform: rotation + uniform scale + translation.
 Parameters: [θ_rot, scale, tx, ty]
 Transform: [x'; y'] = s * R(θ) * [x; y] + [tx; ty]
+
+!!! note "align_smld(..., transform=:affine) stores an approximation"
+    `align_smld` with `transform=:affine` applies a **general** 2D affine
+    correction recovered from a grid of local CC shifts (independent x/y
+    scale + shear is possible), and then reports a best-fit similarity in
+    `info.transforms[i]`. The exact per-dataset 6-parameter affine that was
+    applied is available in `info.diagnostic.affine_coeffs[i]` as
+    `(a, b, c, d, e, f)`, representing the correction
+    `Δx = a·x + b·y + c, Δy = d·x + e·y + f`.
 """
 struct AffineTransform2D <: AbstractAlignTransform
     θ::Float64       # rotation angle (radians)
@@ -188,11 +197,14 @@ Result metadata from `align_smld`.
 
 # Fields
 - `shifts::Vector{Vector{Float64}}`: Recovered shift for each SMLD (shifts[1] = zeros)
-- `transforms::Vector{<:AbstractAlignTransform}`: Full transform for each SMLD (ShiftTransform for :shift, AffineTransform2D/3D for :affine)
+- `transforms::Vector{<:AbstractAlignTransform}`: Full transform for each SMLD (ShiftTransform for :shift, AffineTransform2D/3D for :affine). For `transform=:affine` this is a **similarity-best-fit approximation** of the general affine that was actually applied — the exact coefficients live in `diagnostic`.
 - `elapsed_s::Float64`: Wall time in seconds
 - `method::Symbol`: Method used (`:entropy` or `:fft`)
 - `transform::Symbol`: Transform model used (`:shift` or `:affine`)
 - `backend::Symbol`: Computation backend (`:cpu`)
+- `diagnostic::Union{Nothing, NamedTuple}`: Extra per-dataset information. `nothing` for pure shift alignment. For `transform=:affine`, a NamedTuple with:
+    - `affine_coeffs::Vector{NTuple{6,Float64}}`: per-dataset `(a, b, c, d, e, f)` such that the applied correction was `x -> x - (a·x + b·y + c)`, `y -> y - (d·x + e·y + f)` (summed over the two refinement passes).
+    - `global_shifts::Vector{Vector{Float64}}`: per-dataset global shift applied before the affine correction (summed over both passes).
 """
 struct AlignInfo <: AbstractSMLMInfo
     shifts::Vector{Vector{Float64}}
@@ -201,4 +213,5 @@ struct AlignInfo <: AbstractSMLMInfo
     method::Symbol
     transform::Symbol
     backend::Symbol
+    diagnostic::Union{Nothing, NamedTuple}
 end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -48,13 +48,22 @@ except the last which absorbs any remainder.
 If both are specified, `n_chunks` takes priority.
 """
 function compute_chunk_params(n_frames::Int; chunk_frames::Int=0, n_chunks::Int=0)
+    # Guards: absurd inputs (0-frame SMLDs, or n_chunks exceeding n_frames, or
+    # chunk_frames larger than the whole acquisition) used to produce 0-sized
+    # chunks and blow up downstream.
+    if n_frames <= 1
+        return (frames_per_chunk=max(n_frames, 1), n_chunks=1)
+    end
     if n_chunks > 0
-        # n_chunks specified: divide evenly
+        # Cap n_chunks at n_frames; each chunk must have at least 1 frame
+        n_chunks = min(n_chunks, n_frames)
         frames_per_chunk = n_frames ÷ n_chunks
         return (frames_per_chunk=frames_per_chunk, n_chunks=n_chunks)
     elseif chunk_frames > 0
-        # chunk_frames specified: compute n_chunks, then make equal
+        # Cap chunk_frames at n_frames, then derive n_chunks
+        chunk_frames = min(chunk_frames, n_frames)
         n_chunks = max(1, round(Int, n_frames / chunk_frames))
+        n_chunks = min(n_chunks, n_frames)
         frames_per_chunk = n_frames ÷ n_chunks
         return (frames_per_chunk=frames_per_chunk, n_chunks=n_chunks)
     else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -541,6 +541,60 @@ using Random
         @test info_roi3 isa DC.DriftInfo
     end
 
+    # ========== Edge-case guards ==========
+    @testset "Edge-case guards" begin
+        # normalize_frame with n_frames=1 should not throw DivideError / DomainError
+        @test DC.normalize_frame(1, 1) == 0.0
+        # Legendre polynomial evaluation at a single-frame collapse is finite
+        poly_1f = DC.LegendrePoly1D(2, 1)
+        poly_1f.coefficients .= [0.5, 0.25]
+        @test isfinite(DC.evaluate_at_frame(poly_1f, 1))
+
+        # compute_chunk_params: n_chunks > n_frames should be capped, not 0-sized
+        p1 = DC.compute_chunk_params(10; n_chunks=20)
+        @test p1.n_chunks <= 10
+        @test p1.frames_per_chunk >= 1
+
+        # compute_chunk_params: chunk_frames > n_frames should collapse to 1 chunk
+        p2 = DC.compute_chunk_params(10; chunk_frames=100)
+        @test p2.n_chunks == 1
+        @test p2.frames_per_chunk == 10
+
+        # compute_chunk_params: single-frame input should not divide by zero
+        p3 = DC.compute_chunk_params(1)
+        @test p3.n_chunks == 1
+        @test p3.frames_per_chunk >= 1
+
+        # findshift_damped: σ_px floor prevents collapse when prior_sigma ≈ 0
+        smld_small = DC.filter_emitters(smld_noisy,
+            [e.dataset == 1 for e in smld_noisy.emitters])
+        shift_zero_sigma = DC.findshift_damped(smld_small, smld_small;
+            histbinsize=0.10, prior_shift=[0.0, 0.0], prior_sigma=0.0)
+        @test all(isfinite, shift_zero_sigma)
+
+        # findshift_damped: known shift + non-zero prior recovers approximately
+        shift_imposed_damped = [0.5, -0.3]
+        smld_shifted_d = deepcopy(smld_small)
+        for nn in eachindex(smld_shifted_d.emitters)
+            smld_shifted_d.emitters[nn].x += shift_imposed_damped[1]
+            smld_shifted_d.emitters[nn].y += shift_imposed_damped[2]
+        end
+        # Prior centered near the true shift → damping does not reject the true peak
+        shift_damped = DC.findshift_damped(smld_small, smld_shifted_d;
+            histbinsize=0.10, prior_shift=shift_imposed_damped, prior_sigma=1.0)
+        @test isapprox(shift_damped, shift_imposed_damped; atol=0.15)
+
+        # filter_emitters to an empty mask + driftcorrect-style helpers must not crash
+        empty_mask = falses(length(smld_small.emitters))
+        smld_empty = DC.filter_emitters(smld_small, empty_mask)
+        @test isempty(smld_empty.emitters)
+
+        # findintra! on a dataset with zero emitters is a no-op
+        model_check = DC.LegendrePolynomial(smld_small; degree=2)
+        # Build a model scoped to a bogus dataset index so the per-dataset filter is empty
+        @test_nowarn DC.findintra!(model_check.intra[1], smld_empty, 1, 50)
+    end
+
     # ========== position_frame_correlation ==========
     # Smoke test for the diagnostic function. Wrapped in isdefined so this
     # testset is skipped gracefully if the function hasn't been merged yet.


### PR DESCRIPTION
## Summary

Investigation of a real residual-drift problem on a continuous-mode DNA-PAINT nanoruler dataset (3-spot 20R ruler, ~569k locs / 20k frames, σ_xy≈2.5nm, ORCA-Fusion sCMOS). The corrected render did not resolve the 3 docking spots. This PR lands the validated DME-path determinism fixes and documents a config-only fix for the underlying cause.

## What was wrong

The pipeline output (continuous mode, `n_chunks=10`, `degree=3`, `iterative`) carried a **real, directional** residual drift of ~17nm **along the drift axis** (not isotropic — validated three ways via time-block cross-correlation, and the recovered input drift matched the reported 432.7nm exactly). ~17nm is ~60% of the 20nm ruler pitch, smearing the 3 spots into a blob.

**Root cause:** in continuous mode the per-chunk Legendre polynomials are stitched by endpoint chaining with the inter-shift pinned (large regularization λ). Per-chunk fit bias therefore **accumulates across chunk seams** → coherent directional residual. This is *not* under-convergence: the frozen-tree determinism fix below makes the fit ~3× faster and deterministic but leaves the residual unchanged (11.7→11.9nm), confirming the stitching mechanism.

## The fix (config-only, works on released 0.2.4)

A coarse-to-fine 2-pass:
- **Pass 1** — chunked bootstrap: `dataset_mode=:continuous, n_chunks=10, degree=3, quality=:iterative`.
- **Pass 2** — single-polynomial refine on pass-1 output: `dataset_mode=:continuous, n_chunks=1, degree=2, quality=:iterative`.

Pass 2 works because its input is already sharp (the entropy gradient is well-defined), so a single global polynomial converges and removes the seam-accumulation residual **without reintroducing seams**. This drops the residual 17.4 → 6.5nm — the measurement-noise floor of the CC estimator (a random-split control showed no detectable field-dependence: position-split 3.9nm ≈ random-split 4.2nm).

Why not just `n_chunks=1` in one pass? A single global polynomial cannot bootstrap from the uncorrected, drift-smeared cloud (flat entropy gradient → optimizer stalls, leaving the full ~450nm drift). Chunking is required to bootstrap; the refine removes its stitching cost.

## Changes

1. **Determinism / correctness fixes** (cherry-picked validated commit): freeze the KDTree during each `optimize()` call so Nelder-Mead/BFGS see a deterministic objective (rebuilds driven by an outer loop); `findshift_damped` prior-shift sign fix + σ floor; skip random re-init on warm-start/iterative paths; edge-case guards (`normalize_frame` n=1, chunk caps, empty-subset guards); `align_smld(:affine)` records the exact 6-param affine diagnostic. Adds tests.
2. **Documentation** of the coarse-to-fine 2-pass recipe (`driftcorrect` docstring + `CLAUDE.md`), including the why (bootstrap failure, seam accumulation), the low-degree pass-2 guidance, the cross-chunk-count `warm_start` caveat, and residual-measurement pitfalls.

## Test plan

- Full test suite passes.
- Residual measured independently via time-block cross-correlation (consecutive + endpoint), validated against the known input drift.
