### PR TITLE
Fix continuous-mode inter-stitch non-convergence

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SMLMDriftCorrection"
 uuid = "34bda2d1-2fff-475a-a8c4-7f53d4251312"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["klidke@unm.edu"]
 
 [deps]

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -694,8 +694,15 @@ function _driftcorrect_iterate!(model::LegendrePolynomial, smld::SMLD,
                 warmstart_values = [copy(model.inter[nn].dm) for nn in 1:n_datasets]
             end
         elseif dataset_mode == :continuous
-            # Continuous mode: initialize from polynomial endpoints before optimization
-            _warmstart_inter_continuous!(model, smld, verbose > 1 ? verbose : 0)
+            # Continuous mode: do NOT re-chain inter from polynomial endpoints here.
+            # The endpoint chain is established once in the singlepass init; re-chaining
+            # every iteration overwrote the entropy-refined inter shifts with chain-derived
+            # values, and because the chain is cumulative from chunk 1 it accumulated each
+            # iteration's intra wander downstream — re-injecting a perturbation at the late
+            # chunks faster than the entropy refine could remove it, which sustained an
+            # inter-shift limit cycle (non-convergence) on long/dense continuous data.
+            # Refining inter continuously from the previous iteration converges; continuity
+            # is still enforced softly by the intra boundary prior in findintra!.
             reg_lambda = _estimate_continuous_lambda(model, smld.n_frames, verbose > 1 ? verbose : 0)
             warmstart_values = [copy(model.inter[nn].dm) for nn in 1:n_datasets]
         end


### PR DESCRIPTION
## Summary

Fixes a pathological inter-dataset-shift oscillation (a "limit cycle") in `:iterative` + `:continuous` drift correction that left long / dense acquisitions non-converged — with a large oscillating inter shift and ~0% entropy improvement.

## Root cause

In the iterative refinement loop, the inter-dataset shifts were **re-chained from the intra-polynomial endpoints (`_warmstart_inter_continuous!`) at the start of every iteration**, overwriting the entropy-refined shifts. Because the endpoint chain is **cumulative from chunk 1**, it accumulated each iteration's intra wander downstream and **re-injected a perturbation at the late chunks faster than the entropy refine could remove it** — so the inter shifts oscillated (largest at the late chunk boundaries) and never settled.

## Fix

Establish the endpoint chain **once** (in the singlepass initialization) and then let the inter shifts **refine continuously from the previous iteration**. Continuity across chunk boundaries is still enforced softly by the **intra boundary prior** in `findintra!`.

**Non-breaking** — same public API, no new options.

## Validation

- **CI:** 73 / 73 (independently re-run by Codex review).
- **Inter-shift oscillation / blow-up eliminated.** On `cell1_hek` (100k frames, `n_chunks=10`, `degree=3`) the old code left a **~2.6 µm oscillating inter shift with ~0% entropy improvement**; the fix settles the inter shifts (**~1.5–2.5 µm**) and the residual drift is well-corrected (**residual y-correlation ~0.004–0.04** across runs, vs the old **~0.05 stuck**).
- **An already-converging ruler** (`degree=3`): **4 iters vs 14** before — faster, no regression on cases that already converged.
- **Caveat (honest):** on the very largest acquisitions the iterative `converged` flag may still not trip within the default `max_iterations` budget — the *residual* is good, but the iteration-to-iteration change can stay just above `convergence_tol`. That is a separate, pre-existing property of the merged-cloud intra fit, **not** the inter-stitch oscillation this PR targets (which is resolved).

## Notes

- Patch bump `0.2.5` → `0.2.6`.
- Focused fix only. Exploratory work from the same investigation (`degree_ramp`, an `inter_damping` under-relaxation knob, a `rechain_each_iter` flag) is preserved on the `iterative-degree-ramp` branch and intentionally **not** included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
