### PR TITLE
Continuous mode: fix converged=false false-negative (v0.2.8)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ The reference (DS1) is included so a misaligned reference is fixable, then the r
 
 - `:fft`: Fast cross-correlation only (~10x faster, less accurate)
 - `:singlepass` (default): Single pass of intra then inter correction
-- `:iterative`: Full intra↔inter refinement, one inter pass per iteration (registered: a CC-primary pass; continuous: in-place inter refine, no per-iteration re-chain). Convergence trips when the max change across **both** inter and intra parameters falls below `convergence_tol`. In **registered** mode an entropy **cost-plateau** early exit also applies (relative improvement < `_ENTROPY_REL_TOL`=1e-4), because the merged-cloud entropy is a near-flat basin w.r.t. the inter shifts (entropy blindness, above) and a movement-only test could otherwise run to the iteration cap at ~0% gain. Continuous mode uses the movement criterion only.
+- `:iterative`: Full intra↔inter refinement, one inter pass per iteration (registered: a CC-primary pass; continuous: in-place inter refine, no per-iteration re-chain). Convergence trips when the max change across **both** inter and intra parameters falls below `convergence_tol`. In **both** modes an entropy **cost-plateau** early exit also applies (relative improvement < `_ENTROPY_REL_TOL`=1e-4): a movement-only test can run to the iteration cap at ~0% gain whenever the cost sits in a near-flat basin — registered via merged-cloud entropy blindness (above), continuous because the CC-seeded singlepass already solves the alignment so the iterate loop only wobbles params below the entropy scale. (This previously mis-reported `converged=false` on flat-basin continuous runs that had in fact reached the entropy floor — fixed in 0.2.8 by extending the plateau exit to continuous mode.)
 
 ### Dataset Modes
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SMLMDriftCorrection"
 uuid = "34bda2d1-2fff-475a-a8c4-7f53d4251312"
-version = "0.2.7"
+version = "0.2.8"
 authors = ["klidke@unm.edu"]
 
 [deps]

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -706,19 +706,24 @@ function _driftcorrect_iterate!(model::LegendrePolynomial, smld::SMLD,
         current_entropy = _compute_entropy(smld_corrected, maxn)
         push!(history, current_entropy)
 
-        # Entropy-plateau early-exit. The parameter-movement test below can never
-        # settle: the global merged-cloud entropy is nearly insensitive to a single
-        # dataset's inter shift (one dataset is ~1/N of the cloud), so the inter
-        # parameters sit in a near-flat cost basin — each iteration re-nudges them
-        # > convergence_tol while the entropy is unchanged, and intra wobbles as its
-        # merged-cloud scaffold follows. When the cost itself has stopped improving,
-        # the optimization is done; continuing (and the warm-start retries, which
-        # only re-enter this same loop and so cannot escape a flat basin) just burns
-        # hours. Stop on a relative-improvement plateau. Gated to registered mode:
-        # this is the registered merged-cloud failure mode; continuous mode uses
-        # endpoint-chained inter shifts and keeps its own (b463bd1) convergence path
-        # unchanged, so its behavior is provably unaffected by this fix.
-        if dataset_mode == :registered && length(history) >= 2
+        # Entropy-plateau early-exit. The parameter-movement test below can fail to
+        # settle in a flat entropy basin, so the loop runs to the iteration cap (and
+        # through the warm-start retries, which only re-enter this same loop and so
+        # cannot escape a flat basin) at ~0% cost gain. BOTH dataset modes can reach
+        # such a basin:
+        #   - registered: the global merged-cloud entropy is nearly insensitive to a
+        #     single dataset's inter shift (one dataset is ~1/N of the cloud), so the
+        #     inter parameters sit in a near-flat cost basin and intra wobbles as its
+        #     scaffold follows.
+        #   - continuous: the CC-seeded singlepass init already solves the alignment,
+        #     so the iterate loop only wobbles params below the entropy scale yet above
+        #     convergence_tol (a 513-ruler hv_2ch run reached the converged run's exact
+        #     entropy but reported converged=false at the iteration cap).
+        # When the cost itself has stopped improving the optimization is done, so stop
+        # on a relative-improvement plateau (both modes). The intra Legendre has no
+        # P_0 term, so a flat-entropy param move is degenerate wobble, not a real
+        # refinement being cut short.
+        if length(history) >= 2
             prev_entropy = history[end-1]
             rel_impr = (prev_entropy - current_entropy) / max(abs(prev_entropy), eps())
             if rel_impr < _ENTROPY_REL_TOL

--- a/test/extended_tests.jl
+++ b/test/extended_tests.jl
@@ -785,4 +785,37 @@ using Random
         @test corrected < 0.4 * drifted      # drift substantially removed
         @test corrected < 35.0               # ~3x the ~12 nm observed; robust to RNG/threads
     end
+
+    # --- Continuous mode + iterative: entropy-plateau early-exit reports converged ---
+    # Regression guard for the 0.2.8 fix. A flat-basin continuous iterative run (the
+    # CC-seeded singlepass already solves it, so the iterate loop only wobbles params
+    # below the entropy scale but above convergence_tol) must report converged=true
+    # via the entropy-plateau exit — not run to the iteration cap with converged=false
+    # as it did before the plateau exit was extended from registered to continuous.
+    @testset "Continuous mode iterative converges (entropy plateau)" begin
+        Random.seed!(7)
+        params_ci = StaticSMLMConfig(80.0, 0.13, 30, 1, 4000, 50.0, 2, [0.0, 1.0])
+        (smld_ci0, _) = simulate(params_ci; pattern = Nmer2D(n = 8, d = 0.3),
+            molecule = GenericFluor(; photons = 5000.0, k_on = 0.05, k_off = 50.0),
+            camera = IdealCamera(1:64, 1:64, 0.1))
+        NFci = smld_ci0.n_frames
+        cidrift(f) = (u = (f - 1) / (NFci - 1); (0.10 * u, 0.08 * u))
+        smld_cid = deepcopy(smld_ci0)
+        for e in smld_cid.emitters
+            dx, dy = cidrift(e.frame); e.x += dx; e.y += dy
+        end
+        crm_ci(a, b) = sqrt(sum((e1.x - e2.x)^2 + (e1.y - e2.y)^2
+                                for (e1, e2) in zip(a.emitters, b.emitters)) / length(a.emitters))
+        drifted_ci = 1000 * crm_ci(smld_cid, smld_ci0)
+        (sci, ciinfo) = DC.driftcorrect(smld_cid; quality = :iterative,
+                                         dataset_mode = :continuous, n_chunks = 4,
+                                         degree = 3, max_iterations = 6)
+        corrected_ci = 1000 * crm_ci(sci, smld_ci0)
+        print("continuous iterative: drifted = $(round(drifted_ci, digits=1)) nm -> " *
+              "corrected = $(round(corrected_ci, digits=1)) nm, " *
+              "converged=$(ciinfo.converged), iters=$(ciinfo.iterations)\n")
+        @test ciinfo.converged == true        # plateau (or movement) exit, not the cap
+        @test ciinfo.iterations < 6 * 4       # did not exhaust all warm-start retries at the cap
+        @test corrected_ci < 0.5 * drifted_ci # drift substantially removed
+    end
 end


### PR DESCRIPTION
## Summary
Continuous-mode **iterative** drift correction could report `converged=false` despite having actually converged. The entropy-plateau early-exit (relative improvement < `_ENTROPY_REL_TOL` = 1e-4) was gated to `:registered` mode only; `:continuous` used the parameter-movement test alone.

## Root cause
In continuous mode the CC-seeded singlepass init already solves the alignment, so the iterate loop only wobbles parameters **below the entropy scale but above `convergence_tol`**. The movement-based convergence test therefore never trips, and the run exhausts the iteration cap (and the warm-start retries) at ~0% entropy gain, reporting `converged=false` — a false negative.

Verified on real data: a 513-nanoruler `hv_2ch` continuous/iterative run reached the **exact final entropy** (−413019) of a `converged=true` run of the same config, with excellent residual correlation, yet reported `converged=false` at the iteration cap.

## Fix
Ungate the entropy-plateau early-exit so it applies to **both** modes (one-line condition change in `_driftcorrect_iterate!`). Registered behavior is identical (the condition was already true there). The explanatory comment is rewritten to cover both flat-basin mechanisms.

## Validation
- CI suite: **80/80**
- Extended suite: **170/170**
- New regression test: a continuous + iterative run now reports `converged=true` via the plateau exit (observed: exits at iter 2, drift 74 → 13 nm) instead of running to the iteration cap.

## Version
0.2.7 → 0.2.8 (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)